### PR TITLE
Remove duplicate include statements and change namespace calls

### DIFF
--- a/CSFDemo/CSFDemo.cpp
+++ b/CSFDemo/CSFDemo.cpp
@@ -28,7 +28,7 @@ int main(int argc,char* argv[])
 {
 	//��ȡ�ı������������ڵ���
 	Cfg cfg;
-	string slop_smooth;
+	std::string slop_smooth;
 	cfg.readConfigFile("params.cfg", "slop_smooth", slop_smooth);
 	bool ss = false;
 	if (slop_smooth == "true" || slop_smooth == "True")
@@ -49,17 +49,17 @@ int main(int argc,char* argv[])
 		}
 	}
 
-	string class_threshold;
+	std::string class_threshold;
 	cfg.readConfigFile("params.cfg", "class_threshold", class_threshold);
-	string cloth_resolution;
+	std::string cloth_resolution;
 	cfg.readConfigFile("params.cfg", "cloth_resolution", cloth_resolution);
-	string iterations;
+	std::string iterations;
 	cfg.readConfigFile("params.cfg", "iterations", iterations);
-	string rigidness;
+	std::string rigidness;
 	cfg.readConfigFile("params.cfg", "rigidness", rigidness);
-	string time_step;
+	std::string time_step;
 	cfg.readConfigFile("params.cfg", "time_step", time_step);
-	string terr_pointClouds_filepath;
+	std::string terr_pointClouds_filepath;
 	cfg.readConfigFile("params.cfg", "terr_pointClouds_filepath", terr_pointClouds_filepath);
 
 	CSF csf;

--- a/CSFDemo/CSFDemo.cpp
+++ b/CSFDemo/CSFDemo.cpp
@@ -84,7 +84,7 @@ int main(int argc,char* argv[])
 	std::vector<int> groundIndexes, offGroundIndexes;
 	if (argc == 2 && strcmp(argv[1], "-c")==0)
 	{
-		cout << "Export cloth enabled." << endl;
+		std::cout << "Export cloth enabled." << std::endl;
 		csf.do_filtering(groundIndexes, offGroundIndexes, true);
 	}
 	else

--- a/CSFDemo/CSFDemo.cpp
+++ b/CSFDemo/CSFDemo.cpp
@@ -23,11 +23,10 @@
 #include <time.h>
 #include <cstdlib>
 #include <cstring>
-using namespace std;
 
 int main(int argc,char* argv[])
 {
-	//¶ÁÈ¡ÎÄ±¾²ÎÊı£¬½öÓÃÓÚµ÷ÊÔ
+	//ï¿½ï¿½È¡ï¿½Ä±ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Úµï¿½ï¿½ï¿½
 	Cfg cfg;
 	string slop_smooth;
 	cfg.readConfigFile("params.cfg", "slop_smooth", slop_smooth);
@@ -64,16 +63,16 @@ int main(int argc,char* argv[])
 	cfg.readConfigFile("params.cfg", "terr_pointClouds_filepath", terr_pointClouds_filepath);
 
 	CSF csf;
-	//step 1 ÊäÈëµãÔÆ
+	//step 1 ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
 	csf.readPointsFromFile(terr_pointClouds_filepath);
 
 	clock_t start, end;
 	start = clock();
 
-	//±¸×¢£ºÔÚÊµ¼ÊÊ¹ÓÃ¹ı³ÌÖĞ£¬µãÔÆÊı¾İÓÉÖ÷³ÌĞòÌá¹©£¬µ÷ÓÃº¯ÊıÎª
-	//csf.setPointCloud(pc);//pcÎªPointCloudÀà
+	//ï¿½ï¿½×¢ï¿½ï¿½ï¿½ï¿½Êµï¿½ï¿½Ê¹ï¿½Ã¹ï¿½ï¿½ï¿½ï¿½Ğ£ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½á¹©ï¿½ï¿½ï¿½ï¿½ï¿½Ãºï¿½ï¿½ï¿½Îª
+	//csf.setPointCloud(pc);//pcÎªPointCloudï¿½ï¿½
 
-	//step 2 ÉèÖÃ²ÎÊı
+	//step 2 ï¿½ï¿½ï¿½Ã²ï¿½ï¿½ï¿½
 	csf.params.bSloopSmooth = ss;
 	csf.params.class_threshold = atof(class_threshold.c_str());
 	csf.params.cloth_resolution = atof(cloth_resolution.c_str());
@@ -81,7 +80,7 @@ int main(int argc,char* argv[])
 	csf.params.rigidness = atoi(rigidness.c_str());
 	csf.params.time_step = atof(time_step.c_str());
 
-	//step3 Ö´ĞĞÂË²¨,resultÖĞ´¢´æµÄÊÇµØÃæµãµÄË÷Òı 
+	//step3 Ö´ï¿½ï¿½ï¿½Ë²ï¿½,resultï¿½Ğ´ï¿½ï¿½ï¿½ï¿½ï¿½Çµï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 
 	std::vector<int> groundIndexes, offGroundIndexes;
 	if (argc == 2 && strcmp(argv[1], "-c")==0)
 	{

--- a/CSFDemo/Cfg.h
+++ b/CSFDemo/Cfg.h
@@ -20,7 +20,6 @@
 #include <iostream>  
 #include <string>  
 #include <fstream> 
-using namespace std;
 
 class Cfg
 {
@@ -28,23 +27,23 @@ public:
 	bool readConfigFile(const char * cfgfilepath, const string & key, string & value)
 	{
 		fstream cfgFile;
-		cfgFile.open(cfgfilepath);//´ò¿ªÎÄ¼þ      
+		cfgFile.open(cfgfilepath);//ï¿½ï¿½ï¿½Ä¼ï¿½      
 		if (!cfgFile.is_open())
 		{
 			cout << "can not open cfg file!" << endl;
 			return false;
 		}
 		char tmp[1000];
-		while (!cfgFile.eof())//Ñ­»·¶ÁÈ¡Ã¿Ò»ÐÐ  
+		while (!cfgFile.eof())//Ñ­ï¿½ï¿½ï¿½ï¿½È¡Ã¿Ò»ï¿½ï¿½  
 		{
-			cfgFile.getline(tmp, 1000);//Ã¿ÐÐ¶ÁÈ¡Ç°1000¸ö×Ö·û£¬1000¸öÓ¦¸Ã×ã¹»ÁË  
+			cfgFile.getline(tmp, 1000);//Ã¿ï¿½Ð¶ï¿½È¡Ç°1000ï¿½ï¿½ï¿½Ö·ï¿½ï¿½ï¿½1000ï¿½ï¿½Ó¦ï¿½ï¿½ï¿½ã¹»ï¿½ï¿½  
 			string line(tmp);
-			size_t pos = line.find('=');//ÕÒµ½Ã¿ÐÐµÄ¡°=¡±ºÅÎ»ÖÃ£¬Ö®Ç°ÊÇkeyÖ®ºóÊÇvalue  
+			size_t pos = line.find('=');//ï¿½Òµï¿½Ã¿ï¿½ÐµÄ¡ï¿½=ï¿½ï¿½ï¿½ï¿½Î»ï¿½Ã£ï¿½Ö®Ç°ï¿½ï¿½keyÖ®ï¿½ï¿½ï¿½ï¿½value  
 			if (pos == string::npos) return false;
-			string tmpKey = line.substr(0, pos);//È¡=ºÅÖ®Ç°  
+			string tmpKey = line.substr(0, pos);//È¡=ï¿½ï¿½Ö®Ç°  
 			if (key == tmpKey)
 			{
-				value = line.substr(pos + 1);//È¡=ºÅÖ®ºó  
+				value = line.substr(pos + 1);//È¡=ï¿½ï¿½Ö®ï¿½ï¿½  
 				return true;
 			}
 		}

--- a/CSFDemo/Cfg.h
+++ b/CSFDemo/Cfg.h
@@ -24,7 +24,7 @@
 class Cfg
 {
 public:
-	bool readConfigFile(const char * cfgfilepath, const string & key, string & value)
+	bool readConfigFile(const char * cfgfilepath, const std::string & key, std::string & value)
 	{
 		fstream cfgFile;
 		cfgFile.open(cfgfilepath);//���ļ�      
@@ -37,9 +37,9 @@ public:
 		while (!cfgFile.eof())//ѭ����ȡÿһ��  
 		{
 			cfgFile.getline(tmp, 1000);//ÿ�ж�ȡǰ1000���ַ���1000��Ӧ���㹻��  
-			string line(tmp);
-			size_t pos = line.find('=');//�ҵ�ÿ�еġ�=����λ�ã�֮ǰ��key֮����value  
-			if (pos == string::npos) return false;
+			std::string line(tmp);
+			std::size_t pos = line.find('=');//�ҵ�ÿ�еġ�=����λ�ã�֮ǰ��key֮����value  
+			if (pos == std::string::npos) return false;
 			string tmpKey = line.substr(0, pos);//ȡ=��֮ǰ  
 			if (key == tmpKey)
 			{

--- a/CSFDemo/Cfg.h
+++ b/CSFDemo/Cfg.h
@@ -26,7 +26,7 @@ class Cfg
 public:
 	bool readConfigFile(const char * cfgfilepath, const std::string & key, std::string & value)
 	{
-		fstream cfgFile;
+		std::fstream cfgFile;
 		cfgFile.open(cfgfilepath);//���ļ�      
 		if (!cfgFile.is_open())
 		{
@@ -40,7 +40,7 @@ public:
 			std::string line(tmp);
 			std::size_t pos = line.find('=');//�ҵ�ÿ�еġ�=����λ�ã�֮ǰ��key֮����value  
 			if (pos == std::string::npos) return false;
-			string tmpKey = line.substr(0, pos);//ȡ=��֮ǰ  
+			std::string tmpKey = line.substr(0, pos);//ȡ=��֮ǰ  
 			if (key == tmpKey)
 			{
 				value = line.substr(pos + 1);//ȡ=��֮��  

--- a/CSFDemo/Cfg.h
+++ b/CSFDemo/Cfg.h
@@ -30,7 +30,7 @@ public:
 		cfgFile.open(cfgfilepath);//���ļ�      
 		if (!cfgFile.is_open())
 		{
-			cout << "can not open cfg file!" << endl;
+			std::cout << "can not open cfg file!" << std::endl;
 			return false;
 		}
 		char tmp[1000];

--- a/src/CSF.cpp
+++ b/src/CSF.cpp
@@ -50,7 +50,7 @@ CSF::CSF() {
 CSF::~CSF()
 {}
 
-void CSF::setPointCloud(vector<csf::Point> points) {
+void CSF::setPointCloud(std::vector<csf::Point> points) {
     point_cloud.resize(points.size());
 
     int pointCount = static_cast<int>(points.size());
@@ -89,7 +89,7 @@ void CSF::setPointCloud(csf::PointCloud& pc) {
     }
 }
 
-void CSF::setPointCloud(vector<vector<float> > points) {
+void CSF::setPointCloud(std::vector<std::vector<float> > points) {
     point_cloud.resize(points.size());
     int pointCount = static_cast<int>(points.size());
     #pragma omp parallel for
@@ -102,7 +102,7 @@ void CSF::setPointCloud(vector<vector<float> > points) {
     }
 }
 
-void CSF::readPointsFromFile(string filename) {
+void CSF::readPointsFromFile(std::string filename) {
     this->point_cloud.resize(0);
     read_xyz(filename, this->point_cloud);
 }
@@ -182,7 +182,7 @@ void CSF::do_filtering(std::vector<int>& groundIndexes,
     c2c.calCloud2CloudDist(cloth, point_cloud, groundIndexes, offGroundIndexes);
 }
 
-void CSF::savePoints(vector<int> grp, string path) {
+void CSF::savePoints(std::vector<int> grp, std::string path) {
     if (path == "") {
         return;
     }

--- a/src/CSF.cpp
+++ b/src/CSF.cpp
@@ -112,7 +112,7 @@ void CSF::do_filtering(std::vector<int>& groundIndexes,
                        std::vector<int>& offGroundIndexes,
                        bool              exportCloth) {
     // Terrain
-    cout << "[" << this->index << "] Configuring terrain..." << endl;
+    std::cout << "[" << this->index << "] Configuring terrain..." << std::endl;
     csf::Point bbMin, bbMax;
     point_cloud.computeBoundingBox(bbMin, bbMax);
 
@@ -133,9 +133,9 @@ void CSF::do_filtering(std::vector<int>& groundIndexes,
         std::floor((bbMax.z - bbMin.z) / params.cloth_resolution)
     ) + 2 * clothbuffer_d;
 
-    cout << "[" << this->index << "] Configuring cloth..." << endl;
-    cout << "[" << this->index << "]  - width: " << width_num << " "
-         << "height: " << height_num << endl;
+    std::cout << "[" << this->index << "] Configuring cloth..." << std::endl;
+    std::cout << "[" << this->index << "]  - width: " << width_num << " "
+         << "height: " << height_num << std::endl;
 
     Cloth cloth(
         origin_pos,
@@ -149,13 +149,13 @@ void CSF::do_filtering(std::vector<int>& groundIndexes,
         params.time_step
     );
 
-    cout << "[" << this->index << "] Rasterizing..." << endl;
+    std::cout << "[" << this->index << "] Rasterizing..." << std::endl;
     Rasterization::RasterTerrian(cloth, point_cloud, cloth.getHeightvals());
 
     double time_step2 = params.time_step * params.time_step;
     double gravity    = 0.2;
 
-    cout << "[" << this->index << "] Simulating..." << endl;
+    std::cout << "[" << this->index << "] Simulating..." << std::endl;
     cloth.addForce(Vec3(0, -gravity, 0) * time_step2);
 
     // boost::progress_display pd(params.interations);
@@ -171,7 +171,7 @@ void CSF::do_filtering(std::vector<int>& groundIndexes,
     }
 
     if (params.bSloopSmooth) {
-        cout << "[" << this->index << "]  - post handle..." << endl;
+        std::cout << "[" << this->index << "]  - post handle..." << std::endl;
         cloth.movableFilter();
     }
 
@@ -187,16 +187,16 @@ void CSF::savePoints(std::vector<int> grp, std::string path) {
         return;
     }
 
-    ofstream f1(path.c_str(), ios::out);
+    std::ofstream f1(path.c_str(), ios::out);
 
     if (!f1)
         return;
 
     for (std::size_t i = 0; i < grp.size(); i++) {
-        f1 << fixed << setprecision(8)
+        f1 << std::fixed << std::setprecision(8)
            << point_cloud[grp[i]].x  << "	"
            << point_cloud[grp[i]].z  << "	"
-           << -point_cloud[grp[i]].y << endl;
+           << -point_cloud[grp[i]].y << std::endl;
     }
 
     f1.close();

--- a/src/CSF.cpp
+++ b/src/CSF.cpp
@@ -54,7 +54,7 @@ void CSF::setPointCloud(std::vector<csf::Point> points) {
     point_cloud.resize(points.size());
 
     int pointCount = static_cast<int>(points.size());
-    //#pragma omp parallel for
+    #pragma omp parallel for
     for (int i = 0; i < pointCount; i++) {
         csf::Point las;
         las.x          = points[i].x;
@@ -79,7 +79,7 @@ void CSF::setPointCloud(double *points, int rows) {
 void CSF::setPointCloud(csf::PointCloud& pc) {
     point_cloud.resize(pc.size());
     int pointCount = static_cast<int>(pc.size());
-    //#pragma omp parallel for
+    #pragma omp parallel for
     for (int i = 0; i < pointCount; i++) {
         csf::Point las;
         las.x          = pc[i].x;
@@ -92,7 +92,7 @@ void CSF::setPointCloud(csf::PointCloud& pc) {
 void CSF::setPointCloud(std::vector<std::vector<float> > points) {
     point_cloud.resize(points.size());
     int pointCount = static_cast<int>(points.size());
-    //#pragma omp parallel for
+    #pragma omp parallel for
     for (int i = 0; i < pointCount; i++) {
         csf::Point las;
         las.x          = points[i][0];

--- a/src/CSF.cpp
+++ b/src/CSF.cpp
@@ -54,7 +54,7 @@ void CSF::setPointCloud(std::vector<csf::Point> points) {
     point_cloud.resize(points.size());
 
     int pointCount = static_cast<int>(points.size());
-    #pragma omp parallel for
+    //#pragma omp parallel for
     for (int i = 0; i < pointCount; i++) {
         csf::Point las;
         las.x          = points[i].x;
@@ -79,7 +79,7 @@ void CSF::setPointCloud(double *points, int rows) {
 void CSF::setPointCloud(csf::PointCloud& pc) {
     point_cloud.resize(pc.size());
     int pointCount = static_cast<int>(pc.size());
-    #pragma omp parallel for
+    //#pragma omp parallel for
     for (int i = 0; i < pointCount; i++) {
         csf::Point las;
         las.x          = pc[i].x;
@@ -92,7 +92,7 @@ void CSF::setPointCloud(csf::PointCloud& pc) {
 void CSF::setPointCloud(std::vector<std::vector<float> > points) {
     point_cloud.resize(points.size());
     int pointCount = static_cast<int>(points.size());
-    #pragma omp parallel for
+    //#pragma omp parallel for
     for (int i = 0; i < pointCount; i++) {
         csf::Point las;
         las.x          = points[i][0];

--- a/src/CSF.cpp
+++ b/src/CSF.cpp
@@ -126,11 +126,11 @@ void CSF::do_filtering(std::vector<int>& groundIndexes,
     );
 
     int width_num = static_cast<int>(
-        floor((bbMax.x - bbMin.x) / params.cloth_resolution)
+        std::floor((bbMax.x - bbMin.x) / params.cloth_resolution)
     ) + 2 * clothbuffer_d;
 
     int height_num = static_cast<int>(
-        floor((bbMax.z - bbMin.z) / params.cloth_resolution)
+        std::floor((bbMax.z - bbMin.z) / params.cloth_resolution)
     ) + 2 * clothbuffer_d;
 
     cout << "[" << this->index << "] Configuring cloth..." << endl;

--- a/src/CSF.cpp
+++ b/src/CSF.cpp
@@ -187,7 +187,7 @@ void CSF::savePoints(std::vector<int> grp, std::string path) {
         return;
     }
 
-    std::ofstream f1(path.c_str(), ios::out);
+    std::ofstream f1(path.c_str(), std::ios::out);
 
     if (!f1)
         return;

--- a/src/CSF.h
+++ b/src/CSF.h
@@ -38,7 +38,6 @@
 #include <vector>
 #include <string>
 #include "point_cloud.h"
-using namespace std;
 
 
 struct Params {

--- a/src/CSF.h
+++ b/src/CSF.h
@@ -71,15 +71,15 @@ public:
     ~CSF();
 
     // set pointcloud from vector
-    void setPointCloud(vector<csf::Point> points);
+    void setPointCloud(std::vector<csf::Point> points);
     // set point cloud from a one-dimentional array. it defines a N*3 point cloud by the given rows.
     void setPointCloud(double *points, int rows);
 
     // set point cloud for python
-    void setPointCloud(vector<vector<float> > points);
+    void setPointCloud(std::vector<std::vector<float> > points);
 
     // read pointcloud from txt file: (X Y Z) for each line
-    void readPointsFromFile(string filename);
+    void readPointsFromFile(std::string filename);
 
     inline csf::PointCloud& getPointCloud() {
         return point_cloud;
@@ -90,10 +90,10 @@ public:
     }
 
     // save points to file
-    void savePoints(vector<int> grp, string path);
+    void savePoints(std::vector<int> grp, std::string path);
 
     // get size of pointcloud
-    size_t size() {
+    std::size_t size() {
         return point_cloud.size();
     }
 

--- a/src/Cloth.cpp
+++ b/src/Cloth.cpp
@@ -96,12 +96,12 @@ Cloth::Cloth(const Vec3& _origin_pos,
 
 double Cloth::timeStep() {
     int particleCount = static_cast<int>(particles.size());
-    #pragma omp parallel for
+    //#pragma omp parallel for
     for (int i = 0; i < particleCount; i++) {
         particles[i].timeStep();
     }
 
-    #pragma omp parallel for
+    //#pragma omp parallel for
     for (int j = 0; j < particleCount; j++) {
         particles[j].satisfyConstraintSelf(constraint_iterations);
     }
@@ -128,7 +128,7 @@ void Cloth::addForce(const Vec3 direction) {
 
 void Cloth::terrCollision() {
     int particleCount = static_cast<int>(particles.size());
-    #pragma omp parallel for
+    //#pragma omp parallel for
     for (int i = 0; i < particleCount; i++) {
         Vec3 v = particles[i].getPos();
 

--- a/src/Cloth.cpp
+++ b/src/Cloth.cpp
@@ -372,13 +372,13 @@ void Cloth::saveToFile(std::string path) {
         filepath = path;
     }
 
-    ofstream f1(filepath.c_str());
+    std::ofstream f1(filepath.c_str());
 
     if (!f1)
         return;
 
     for (std::size_t i = 0; i < particles.size(); i++) {
-        f1 << fixed << setprecision(8) << particles[i].getPos().f[0] << "	"<< particles[i].getPos().f[2] << "	"<< -particles[i].getPos().f[1] << endl;
+        f1 << std::fixed << std::setprecision(8) << particles[i].getPos().f[0] << "	"<< particles[i].getPos().f[2] << "	"<< -particles[i].getPos().f[1] << std::endl;
     }
 
     f1.close();
@@ -393,15 +393,15 @@ void Cloth::saveMovableToFile(std::string path) {
         filepath = path;
     }
 
-    ofstream f1(filepath.c_str());
+    std::ofstream f1(filepath.c_str());
 
     if (!f1)
         return;
 
     for (std::size_t i = 0; i < particles.size(); i++) {
         if (particles[i].isMovable()) {
-            f1 << fixed << setprecision(8) << particles[i].getPos().f[0] << "	"
-               << particles[i].getPos().f[2] << "	"<< -particles[i].getPos().f[1] << endl;
+            f1 << std::fixed << std::setprecision(8) << particles[i].getPos().f[0] << "	"
+               << particles[i].getPos().f[2] << "	"<< -particles[i].getPos().f[1] << std::endl;
         }
     }
 

--- a/src/Cloth.cpp
+++ b/src/Cloth.cpp
@@ -147,7 +147,7 @@ void Cloth::movableFilter() {
             Particle *ptc = getParticle(x, y);
 
             if (ptc->isMovable() && !ptc->isVisited) {
-                queue<int> que;
+                std::queue<int> que;
                 std::vector<XY> connected; // store the connected component
                 std::vector<std::vector<int> > neibors;
                 int sum   = 1;
@@ -332,7 +332,7 @@ void Cloth::handle_slop_connected(std::vector<int> edgePoints, std::vector<XY> c
 
     for (std::size_t i = 0; i < connected.size(); i++) visited.push_back(false);
 
-    queue<int> que;
+    std::queue<int> que;
 
     for (std::size_t i = 0; i < edgePoints.size(); i++) {
         que.push(edgePoints[i]);

--- a/src/Cloth.cpp
+++ b/src/Cloth.cpp
@@ -140,7 +140,7 @@ void Cloth::terrCollision() {
 }
 
 void Cloth::movableFilter() {
-    vector<Particle> tmpParticles;
+    std::vector<Particle> tmpParticles;
 
     for (int x = 0; x < num_particles_width; x++) {
         for (int y = 0; y < num_particles_height; y++) {
@@ -148,8 +148,8 @@ void Cloth::movableFilter() {
 
             if (ptc->isMovable() && !ptc->isVisited) {
                 queue<int> que;
-                vector<XY> connected; // store the connected component
-                vector<vector<int> > neibors;
+                std::vector<XY> connected; // store the connected component
+                std::vector<std::vector<int> > neibors;
                 int sum   = 1;
                 int index = y * num_particles_width + x;
 
@@ -165,7 +165,7 @@ void Cloth::movableFilter() {
                     que.pop();
                     int cur_x = ptc_f->pos_x;
                     int cur_y = ptc_f->pos_y;
-                    vector<int> neibor;
+                    std::vector<int> neibor;
 
                     if (cur_x > 0) {
                         Particle *ptc_left = getParticle(cur_x - 1, cur_y);
@@ -238,7 +238,7 @@ void Cloth::movableFilter() {
                 }
 
                 if (sum > MAX_PARTICLE_FOR_POSTPROCESSIN) {
-                    vector<int> edgePoints = findUnmovablePoint(connected);
+                    std::vector<int> edgePoints = findUnmovablePoint(connected);
                     handle_slop_connected(edgePoints, connected, neibors);
                 }
             }
@@ -246,10 +246,10 @@ void Cloth::movableFilter() {
     }
 }
 
-vector<int> Cloth::findUnmovablePoint(vector<XY> connected) {
-    vector<int> edgePoints;
+std::vector<int> Cloth::findUnmovablePoint(std::vector<XY> connected) {
+    std::vector<int> edgePoints;
 
-    for (size_t i = 0; i < connected.size(); i++) {
+    for (std::size_t i = 0; i < connected.size(); i++) {
         int x         = connected[i].x;
         int y         = connected[i].y;
         int index     = y * num_particles_width + x;
@@ -327,14 +327,14 @@ vector<int> Cloth::findUnmovablePoint(vector<XY> connected) {
     return edgePoints;
 }
 
-void Cloth::handle_slop_connected(vector<int> edgePoints, vector<XY> connected, vector<vector<int> > neibors) {
-    vector<bool> visited;
+void Cloth::handle_slop_connected(std::vector<int> edgePoints, std::vector<XY> connected, std::vector<std::vector<int> > neibors) {
+    std::vector<bool> visited;
 
-    for (size_t i = 0; i < connected.size(); i++) visited.push_back(false);
+    for (std::size_t i = 0; i < connected.size(); i++) visited.push_back(false);
 
     queue<int> que;
 
-    for (size_t i = 0; i < edgePoints.size(); i++) {
+    for (std::size_t i = 0; i < edgePoints.size(); i++) {
         que.push(edgePoints[i]);
         visited[edgePoints[i]] = true;
     }
@@ -345,7 +345,7 @@ void Cloth::handle_slop_connected(vector<int> edgePoints, vector<XY> connected, 
 
         int index_center = connected[index].y * num_particles_width + connected[index].x;
 
-        for (size_t i = 0; i < neibors[index].size(); i++) {
+        for (std::size_t i = 0; i < neibors[index].size(); i++) {
             int index_neibor = connected[neibors[index][i]].y * num_particles_width + connected[neibors[index][i]].x;
 
             if ((fabs(heightvals[index_center] - heightvals[index_neibor]) < smoothThreshold) &&
@@ -363,8 +363,8 @@ void Cloth::handle_slop_connected(vector<int> edgePoints, vector<XY> connected, 
     }
 }
 
-void Cloth::saveToFile(string path) {
-    string filepath = "cloth_nodes.txt";
+void Cloth::saveToFile(std::string path) {
+    std::string filepath = "cloth_nodes.txt";
 
     if (path == "") {
         filepath = "cloth_nodes.txt";
@@ -377,15 +377,15 @@ void Cloth::saveToFile(string path) {
     if (!f1)
         return;
 
-    for (size_t i = 0; i < particles.size(); i++) {
+    for (std::size_t i = 0; i < particles.size(); i++) {
         f1 << fixed << setprecision(8) << particles[i].getPos().f[0] << "	"<< particles[i].getPos().f[2] << "	"<< -particles[i].getPos().f[1] << endl;
     }
 
     f1.close();
 }
 
-void Cloth::saveMovableToFile(string path) {
-    string filepath = "cloth_movable.txt";
+void Cloth::saveMovableToFile(std::string path) {
+    std::string filepath = "cloth_movable.txt";
 
     if (path == "") {
         filepath = "cloth_movable.txt";
@@ -398,7 +398,7 @@ void Cloth::saveMovableToFile(string path) {
     if (!f1)
         return;
 
-    for (size_t i = 0; i < particles.size(); i++) {
+    for (std::size_t i = 0; i < particles.size(); i++) {
         if (particles[i].isMovable()) {
             f1 << fixed << setprecision(8) << particles[i].getPos().f[0] << "	"
                << particles[i].getPos().f[2] << "	"<< -particles[i].getPos().f[1] << endl;

--- a/src/Cloth.cpp
+++ b/src/Cloth.cpp
@@ -96,12 +96,12 @@ Cloth::Cloth(const Vec3& _origin_pos,
 
 double Cloth::timeStep() {
     int particleCount = static_cast<int>(particles.size());
-    //#pragma omp parallel for
+    #pragma omp parallel for
     for (int i = 0; i < particleCount; i++) {
         particles[i].timeStep();
     }
 
-    //#pragma omp parallel for
+    #pragma omp parallel for
     for (int j = 0; j < particleCount; j++) {
         particles[j].satisfyConstraintSelf(constraint_iterations);
     }
@@ -128,7 +128,7 @@ void Cloth::addForce(const Vec3 direction) {
 
 void Cloth::terrCollision() {
     int particleCount = static_cast<int>(particles.size());
-    //#pragma omp parallel for
+    #pragma omp parallel for
     for (int i = 0; i < particleCount; i++) {
         Vec3 v = particles[i].getPos();
 

--- a/src/Cloth.h
+++ b/src/Cloth.h
@@ -47,17 +47,11 @@
 #include <vector>
 #include <iostream>
 #include <omp.h>
-#include <iostream>
 #include <sstream>
 #include <list>
 #include <cmath>
-#include <vector>
 #include <string>
-#include <list>
 #include <queue>
-#include <cmath>
-#include <list>
-using namespace std;
 
 #include "Vec3.h"
 #include "Particle.h"

--- a/src/Cloth.h
+++ b/src/Cloth.h
@@ -86,7 +86,7 @@ public:
 
     Vec3 origin_pos;
     double step_x, step_y;
-    vector<double> heightvals; // height values
+    std::vector<double> heightvals; // height values
     int num_particles_width;   // number of particles in width direction
     int num_particles_height;  // number of particles in height direction
 
@@ -105,7 +105,7 @@ public:
         return num_particles_width * num_particles_height;
     }
 
-    size_t get1DIndex(int x, int y) {
+    std::size_t get1DIndex(int x, int y) {
         return y * num_particles_width + x;
     }
 
@@ -146,15 +146,15 @@ public:
 
     void movableFilter();
 
-    vector<int> findUnmovablePoint(vector<XY> connected);
+    std::vector<int> findUnmovablePoint(std::vector<XY> connected);
 
-    void        handle_slop_connected(vector<int>          edgePoints,
-                                      vector<XY>           connected,
-                                      vector<vector<int> > neibors);
+    void        handle_slop_connected(std::vector<int>          edgePoints,
+                                      std::vector<XY>           connected,
+                                      std::vector<std::vector<int> > neibors);
 
-    void saveToFile(string path = "");
+    void saveToFile(std::string path = "");
 
-    void saveMovableToFile(string path = "");
+    void saveMovableToFile(std::string path = "");
 };
 
 

--- a/src/Particle.h
+++ b/src/Particle.h
@@ -145,7 +145,7 @@ public:
     }
 
     void printself(std::string s = "") {
-        cout << s << ": " << this->getPos().f[0] << " movable:  " << this->movable << endl;
+        std::cout << s << ": " << this->getPos().f[0] << " movable:  " << this->movable << std::endl;
     }
 };
 

--- a/src/Particle.h
+++ b/src/Particle.h
@@ -54,7 +54,7 @@ public:
     int pos_y;
     int c_pos;
 
-    vector<Particle *> neighborsList;
+    std::vector<Particle *> neighborsList;
 
     std::vector<int> correspondingLidarPointList;
     std::size_t nearestPointIndex;
@@ -144,7 +144,7 @@ public:
         accumulated_normal = Vec3(0, 0, 0);
     }
 
-    void printself(string s = "") {
+    void printself(std::string s = "") {
         cout << s << ": " << this->getPos().f[0] << " movable:  " << this->movable << endl;
     }
 };

--- a/src/Rasterization.cpp
+++ b/src/Rasterization.cpp
@@ -57,7 +57,7 @@ double Rasterization::findHeightValByScanline(Particle *p, Cloth& cloth) {
 
 double Rasterization::findHeightValByNeighbor(Particle *p, Cloth& cloth) {
     queue<Particle *>  nqueue;
-    vector<Particle *> pbacklist;
+    std::vector<Particle *> pbacklist;
     int neiborsize = p->neighborsList.size();
 
     for (int i = 0; i < neiborsize; i++) {
@@ -101,7 +101,7 @@ double Rasterization::findHeightValByNeighbor(Particle *p, Cloth& cloth) {
 
 void Rasterization::RasterTerrian(Cloth          & cloth,
                                   csf::PointCloud& pc,
-                                  vector<double> & heightVal) {
+                                  std::vector<double> & heightVal) {
 
     for (std::size_t i = 0; i < pc.size(); i++) {
         double pc_x = pc[i].x;

--- a/src/Rasterization.cpp
+++ b/src/Rasterization.cpp
@@ -56,7 +56,7 @@ double Rasterization::findHeightValByScanline(Particle *p, Cloth& cloth) {
 
 
 double Rasterization::findHeightValByNeighbor(Particle *p, Cloth& cloth) {
-    queue<Particle *>  nqueue;
+    std::queue<Particle *>  nqueue;
     std::vector<Particle *> pbacklist;
     int neiborsize = p->neighborsList.size();
 

--- a/src/Rasterization.h
+++ b/src/Rasterization.h
@@ -38,7 +38,7 @@ public:
 
     void static   RasterTerrian(Cloth          & cloth,
                                 csf::PointCloud& pc,
-                                vector<double> & heightVal);
+                                std::vector<double> & heightVal);
 };
 
 #endif // ifndef _KNN_H_

--- a/src/Vec3.h
+++ b/src/Vec3.h
@@ -24,7 +24,6 @@
 #include <iostream>
 #include <iomanip>
 
-using namespace std;
 
 // a minimal vector class of 3 doubles and overloaded math operators
 class Vec3 {

--- a/src/XYZReader.cpp
+++ b/src/XYZReader.cpp
@@ -23,10 +23,10 @@
 #include <cstdlib>
 
 
-void read_xyz(string fname, csf::PointCloud& pointcloud) {
+void read_xyz(std::string fname, csf::PointCloud& pointcloud) {
     ifstream fin(fname.c_str(), ios::in);
     char     line[500];
-    string   x, y, z;
+    std::string   x, y, z;
 
     while (fin.getline(line, sizeof(line))) {
         stringstream words(line);

--- a/src/XYZReader.cpp
+++ b/src/XYZReader.cpp
@@ -24,12 +24,12 @@
 
 
 void read_xyz(std::string fname, csf::PointCloud& pointcloud) {
-    ifstream fin(fname.c_str(), std::ios::in);
+    std::ifstream fin(fname.c_str(), std::ios::in);
     char     line[500];
     std::string   x, y, z;
 
     while (fin.getline(line, sizeof(line))) {
-        stringstream words(line);
+        std::stringstream words(line);
 
         words >> x;
         words >> y;

--- a/src/XYZReader.cpp
+++ b/src/XYZReader.cpp
@@ -22,7 +22,6 @@
 #include <fstream>
 #include <cstdlib>
 
-using namespace std;
 
 void read_xyz(string fname, csf::PointCloud& pointcloud) {
     ifstream fin(fname.c_str(), ios::in);

--- a/src/XYZReader.cpp
+++ b/src/XYZReader.cpp
@@ -24,7 +24,7 @@
 
 
 void read_xyz(std::string fname, csf::PointCloud& pointcloud) {
-    ifstream fin(fname.c_str(), ios::in);
+    ifstream fin(fname.c_str(), std::ios::in);
     char     line[500];
     std::string   x, y, z;
 

--- a/src/XYZReader.h
+++ b/src/XYZReader.h
@@ -22,7 +22,6 @@
 #include <string>
 #include <vector>
 
-using namespace std;
 
 #include "point_cloud.h"
 

--- a/src/XYZReader.h
+++ b/src/XYZReader.h
@@ -25,7 +25,7 @@
 
 #include "point_cloud.h"
 
-void read_xyz(string fname, csf::PointCloud& pointcloud);
+void read_xyz(std::string fname, csf::PointCloud& pointcloud);
 
 
 #endif // ifndef XYZ_READER_H_


### PR DESCRIPTION
This pull request makes small changes to improve consistency and code style.

1. Remove duplicated `include` statements in `Cloth.h`
2. Remove instances of `using namespace std;` and modify to use `std::` consistently throughout the entire project
3. Comment out the `pragma omp` for loops that blocks compilation in `CSF.cpp` and `Cloth.cpp`. These were already commented out in `Rasterization.cpp`

This pull request only modifies the C++ files and CSFDemo. The python and matlab extension code is not changed at all. 
I have tested it locally on my computer and the project compiles and the demo runs on linux.