### PR TITLE
Use updated version of CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(OpenMP)
 
 add_subdirectory(src)
 
-option (BUILD_DEMO "Build csfdemo" ON)
+option (BUILD_DEMO "Build csfdemo" OFF)
 
 if (BUILD_DEMO)
   add_subdirectory (CSFDemo)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,12 @@
-cmake_minimum_required(VERSION 2.8)
-project(CSF)
+cmake_minimum_required(VERSION 3.10)
+project(CSF LANGUAGES CXX)
+
+find_package(OpenMP)
+
 add_subdirectory(src)
-add_subdirectory(CSFDemo)
+
+option (BUILD_DEMO "Build csfdemo" ON)
+
+if (BUILD_DEMO)
+  add_subdirectory (CSFDemo)
+endif()

--- a/CSFDemo/CMakeLists.txt
+++ b/CSFDemo/CMakeLists.txt
@@ -1,6 +1,10 @@
-cmake_minimum_required(VERSION 2.8)
-include_directories(${PROJECT_SOURCE_DIR}/CSFDemo)
-set(APP_SRC CSFDemo.cpp)
-set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
-add_executable(csfdemo ${APP_SRC})
-target_link_libraries(csfdemo CSF)
+cmake_minimum_required(VERSION 3.10)
+
+set(EXECUTABLE_OUTPUT_PATH ../bin)
+
+add_executable(csfdemo CSFDemo.cpp)
+
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(csfdemo 
+                        PUBLIC CSF OpenMP::OpenMP_CXX)
+endif()

--- a/README.md
+++ b/README.md
@@ -83,10 +83,23 @@ Now, CSF is built by CMake, it produces a static library, which can be used by o
 #### linux
 To build the library, run:
 ```bash
-cmake .
+mkdir build #or other name
+cd build
+cmake ..
 make
 sudo make install
 ```
+or if you want to build the library and the demo executable `csfdemo`
+
+```bash
+mkdir build #or other name
+cd build
+cmake -DBUILD_DEMO=ON ..
+make
+sudo make install
+
+```
+
 #### Windows
 You can use CMake GUI to generate visual studio solution file.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,21 +1,35 @@
-cmake_minimum_required(VERSION 2.8)
-project(CSF)
+project(CSF LANGUAGES CXX)
 
-find_package(OpenMP)
-if (OPENMP_FOUND)
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
-endif()
-
-file(GLOB_RECURSE sources *.cpp)
-
-ADD_LIBRARY(CSF STATIC ${sources})
-
-set_target_properties(CSF PROPERTIES OUTPUT_NAME "CSF")
+set (package_name "CSF")
 
 set(LIBRARY_OUTPUT_PATH ../lib)
 
-install(TARGETS CSF LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
+find_package(OpenMP)
 
-install(FILES CSF.h DESTINATION include)
+add_library(CSF STATIC
+${CMAKE_CURRENT_LIST_DIR}/c2cdist.cpp
+${CMAKE_CURRENT_LIST_DIR}/c2cdist.h
+${CMAKE_CURRENT_LIST_DIR}/Cloth.cpp
+${CMAKE_CURRENT_LIST_DIR}/Cloth.h
+${CMAKE_CURRENT_LIST_DIR}/Constraint.cpp
+${CMAKE_CURRENT_LIST_DIR}/Constraint.h
+${CMAKE_CURRENT_LIST_DIR}/CSF.cpp
+${CMAKE_CURRENT_LIST_DIR}/CSF.h
+${CMAKE_CURRENT_LIST_DIR}/Particle.cpp
+${CMAKE_CURRENT_LIST_DIR}/Particle.h
+${CMAKE_CURRENT_LIST_DIR}/point_cloud.cpp
+${CMAKE_CURRENT_LIST_DIR}/point_cloud.h
+${CMAKE_CURRENT_LIST_DIR}/Rasterization.cpp
+${CMAKE_CURRENT_LIST_DIR}/Rasterization.h
+${CMAKE_CURRENT_LIST_DIR}/Vec3.h
+${CMAKE_CURRENT_LIST_DIR}/XYZReader.cpp
+${CMAKE_CURRENT_LIST_DIR}/XYZReader.h
+)
+
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(CSF PUBLIC OpenMP::OpenMP_CXX)
+endif()
+
+install(TARGETS CSF
+        DESTINATION ../lib
+)


### PR DESCRIPTION
This pull request updates `CMake` to 3.10. I think this fixes #19.

-change to out of source build
-add commandline option to build demo
-update README.md

I have tested on linux but nothing else. I do not know if this impacts the python or matlab builds.