### PR TITLE
fix unused parameter warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,7 @@ ${CMAKE_CURRENT_LIST_DIR}/XYZReader.h
 
 if(OpenMP_CXX_FOUND)
     target_link_libraries(CSF PUBLIC OpenMP::OpenMP_CXX)
+    target_compile_options(CSF PRIVATE -Werror -Wall -Wextra)
 endif()
 
 install(TARGETS CSF

--- a/src/Rasterization.cpp
+++ b/src/Rasterization.cpp
@@ -51,11 +51,11 @@ double Rasterization::findHeightValByScanline(Particle *p, Cloth& cloth) {
             return crresHeight;
     }
 
-    return findHeightValByNeighbor(p, cloth);
+    return findHeightValByNeighbor(p);
 }
 
 
-double Rasterization::findHeightValByNeighbor(Particle *p, Cloth& cloth) {
+double Rasterization::findHeightValByNeighbor(Particle *p) {
     std::queue<Particle *>  nqueue;
     std::vector<Particle *> pbacklist;
     int neiborsize = p->neighborsList.size();

--- a/src/Rasterization.h
+++ b/src/Rasterization.h
@@ -33,7 +33,7 @@ public:
 
     // for a cloth particle, if no corresponding lidar point are found.
     // the heightval are set as its neighbor's
-    double static findHeightValByNeighbor(Particle *p, Cloth& cloth);
+    double static findHeightValByNeighbor(Particle *p);
     double static findHeightValByScanline(Particle *p, Cloth& cloth);
 
     void static   RasterTerrian(Cloth          & cloth,


### PR DESCRIPTION
This pull requests fixes errors from compiling with ` -Werror -Wall -Wextra` 

` error: unused parameter ‘cloth’ [-Werror=unused-parameter]
 double Rasterization::findHeightValByNeighbor(Particle *p, Cloth& cloth) {`